### PR TITLE
Make unit tests Linux-compatible

### DIFF
--- a/Tests/CompactMapTests.swift
+++ b/Tests/CompactMapTests.swift
@@ -8,61 +8,73 @@ import XCTest
 import CollectionConcurrencyKit
 
 final class CompactMapTests: TestCase {
-    func testNonThrowingAsyncCompactMap() async {
-        let values = await array.asyncCompactMap { int in
-            await int == 3 ? nil : collector.collectAndTransform(int)
-        }
-
-        XCTAssertEqual(values, ["0", "1", "2", "4"])
-    }
-
-    func testThrowingAsyncCompactMapThatDoesNotThrow() async throws {
-        let values = try await array.asyncCompactMap { int in
-            try await int == 3 ? nil : collector.tryCollectAndTransform(int)
-        }
-
-        XCTAssertEqual(values, ["0", "1", "2", "4"])
-    }
-
-    func testThrowingAsyncCompactMapThatThrows() async {
-        await verifyErrorThrown { error in
-            try await array.asyncCompactMap { int in
-                int == 2 ? nil : try await self.collector.tryCollectAndTransform(
-                    int,
-                    throwError: int == 3 ? error : nil
-                )
+    func testNonThrowingAsyncCompactMap() {
+        runAsyncTest { array, collector in
+            let values = await array.asyncCompactMap { int in
+                await int == 3 ? nil : collector.collectAndTransform(int)
             }
-        }
 
-        XCTAssertEqual(collector.values, [0, 1])
+            XCTAssertEqual(values, ["0", "1", "2", "4"])
+        }
     }
 
-    func testNonThrowingConcurrentCompactMap() async {
-        let values = await array.concurrentCompactMap { int in
-            await int == 3 ? nil : self.collector.collectAndTransform(int)
-        }
-
-        XCTAssertEqual(values, ["0", "1", "2", "4"])
-    }
-
-    func testThrowingConcurrentCompactMapThatDoesNotThrow() async throws {
-        let values = try await array.concurrentCompactMap { int in
-            try await int == 3 ? nil : self.collector.tryCollectAndTransform(int)
-        }
-
-        XCTAssertEqual(values, ["0", "1", "2", "4"])
-    }
-
-    func testThrowingConcurrentCompactMapThatThrows() async {
-        await verifyErrorThrown { error in
-            try await array.concurrentCompactMap { int in
-                int == 2 ? nil : try await self.collector.tryCollectAndTransform(
-                    int,
-                    throwError: int == 3 ? error : nil
-                )
+    func testThrowingAsyncCompactMapThatDoesNotThrow() {
+        runAsyncTest { array, collector in
+            let values = try await array.asyncCompactMap { int in
+                try await int == 3 ? nil : collector.tryCollectAndTransform(int)
             }
-        }
 
-        XCTAssertEqual(collector.values.sorted(), [0, 1, 4])
+            XCTAssertEqual(values, ["0", "1", "2", "4"])
+        }
+    }
+
+    func testThrowingAsyncCompactMapThatThrows() {
+        runAsyncTest { array, collector in
+            await self.verifyErrorThrown { error in
+                try await array.asyncCompactMap { int in
+                    int == 2 ? nil : try await collector.tryCollectAndTransform(
+                        int,
+                        throwError: int == 3 ? error : nil
+                    )
+                }
+            }
+
+            XCTAssertEqual(collector.values, [0, 1])
+        }
+    }
+
+    func testNonThrowingConcurrentCompactMap() {
+        runAsyncTest { array, collector in
+            let values = await array.concurrentCompactMap { int in
+                await int == 3 ? nil : collector.collectAndTransform(int)
+            }
+
+            XCTAssertEqual(values, ["0", "1", "2", "4"])
+        }
+    }
+
+    func testThrowingConcurrentCompactMapThatDoesNotThrow() {
+        runAsyncTest { array, collector in
+            let values = try await array.concurrentCompactMap { int in
+                try await int == 3 ? nil : collector.tryCollectAndTransform(int)
+            }
+
+            XCTAssertEqual(values, ["0", "1", "2", "4"])
+        }
+    }
+
+    func testThrowingConcurrentCompactMapThatThrows() {
+        runAsyncTest { array, collector in
+            await self.verifyErrorThrown { error in
+                try await array.concurrentCompactMap { int in
+                    int == 2 ? nil : try await self.collector.tryCollectAndTransform(
+                        int,
+                        throwError: int == 3 ? error : nil
+                    )
+                }
+            }
+
+            XCTAssertEqual(collector.values.sorted(), [0, 1, 4])
+        }
     }
 }

--- a/Tests/FlatMapTests.swift
+++ b/Tests/FlatMapTests.swift
@@ -8,61 +8,73 @@ import XCTest
 import CollectionConcurrencyKit
 
 final class FlatMapTests: TestCase {
-    func testNonThrowingAsyncFlatMap() async {
-        let values = await array.asyncFlatMap {
-            await collector.collectAndDuplicate($0)
-        }
-
-        XCTAssertEqual(values, array.flatMap { [$0, $0] })
-    }
-
-    func testThrowingAsyncFlatMapThatDoesNotThrow() async throws {
-        let values = try await array.asyncFlatMap {
-            try await collector.tryCollectAndDuplicate($0)
-        }
-
-        XCTAssertEqual(values, array.flatMap { [$0, $0] })
-    }
-
-    func testThrowingAsyncFlatMapThatThrows() async {
-        await verifyErrorThrown { error in
-            try await array.asyncFlatMap { int in
-                try await self.collector.tryCollectAndDuplicate(
-                    int,
-                    throwError: int == 3 ? error : nil
-                )
+    func testNonThrowingAsyncFlatMap() {
+        runAsyncTest { array, collector in
+            let values = await array.asyncFlatMap {
+                await collector.collectAndDuplicate($0)
             }
-        }
 
-        XCTAssertEqual(collector.values, [0, 1, 2])
+            XCTAssertEqual(values, array.flatMap { [$0, $0] })
+        }
     }
 
-    func testNonThrowingConcurrentFlatMap() async {
-        let values = await array.concurrentFlatMap {
-            await self.collector.collectAndDuplicate($0)
-        }
-
-        XCTAssertEqual(values, array.flatMap { [$0, $0] })
-    }
-
-    func testThrowingConcurrentFlatMapThatDoesNotThrow() async throws {
-        let values = try await array.concurrentFlatMap {
-            try await self.collector.tryCollectAndDuplicate($0)
-        }
-
-        XCTAssertEqual(values, array.flatMap { [$0, $0] })
-    }
-
-    func testThrowingConcurrentFlatMapThatThrows() async {
-        await verifyErrorThrown { error in
-            try await array.concurrentFlatMap { int in
-                try await self.collector.tryCollectAndDuplicate(
-                    int,
-                    throwError: int == 3 ? error : nil
-                )
+    func testThrowingAsyncFlatMapThatDoesNotThrow() {
+        runAsyncTest { array, collector in
+            let values = try await array.asyncFlatMap {
+                try await collector.tryCollectAndDuplicate($0)
             }
-        }
 
-        XCTAssertEqual(collector.values.sorted(), [0, 1, 2, 4])
+            XCTAssertEqual(values, array.flatMap { [$0, $0] })
+        }
+    }
+
+    func testThrowingAsyncFlatMapThatThrows() {
+        runAsyncTest { array, collector in
+            await self.verifyErrorThrown { error in
+                try await array.asyncFlatMap { int in
+                    try await collector.tryCollectAndDuplicate(
+                        int,
+                        throwError: int == 3 ? error : nil
+                    )
+                }
+            }
+
+            XCTAssertEqual(collector.values, [0, 1, 2])
+        }
+    }
+
+    func testNonThrowingConcurrentFlatMap() {
+        runAsyncTest { array, collector in
+            let values = await array.concurrentFlatMap {
+                await collector.collectAndDuplicate($0)
+            }
+
+            XCTAssertEqual(values, array.flatMap { [$0, $0] })
+        }
+    }
+
+    func testThrowingConcurrentFlatMapThatDoesNotThrow() {
+        runAsyncTest { array, collector in
+            let values = try await array.concurrentFlatMap {
+                try await collector.tryCollectAndDuplicate($0)
+            }
+
+            XCTAssertEqual(values, array.flatMap { [$0, $0] })
+        }
+    }
+
+    func testThrowingConcurrentFlatMapThatThrows() {
+        runAsyncTest { array, collector in
+            await self.verifyErrorThrown { error in
+                try await array.concurrentFlatMap { int in
+                    try await collector.tryCollectAndDuplicate(
+                        int,
+                        throwError: int == 3 ? error : nil
+                    )
+                }
+            }
+
+            XCTAssertEqual(collector.values.sorted(), [0, 1, 2, 4])
+        }
     }
 }

--- a/Tests/MapTests.swift
+++ b/Tests/MapTests.swift
@@ -8,58 +8,70 @@ import XCTest
 import CollectionConcurrencyKit
 
 final class MapTests: TestCase {
-    func testNonThrowingAsyncMap() async {
-        let values = await array.asyncMap { await collector.collectAndTransform($0) }
-        XCTAssertEqual(values, array.map(String.init))
-    }
-
-    func testThrowingAsyncMapThatDoesNotThrow() async throws {
-        let values = try await array.asyncMap {
-            try await collector.tryCollectAndTransform($0)
+    func testNonThrowingAsyncMap() {
+        runAsyncTest { array, collector in
+            let values = await array.asyncMap { await collector.collectAndTransform($0) }
+            XCTAssertEqual(values, array.map(String.init))
         }
-
-        XCTAssertEqual(values, array.map(String.init))
     }
 
-    func testThrowingAsyncMapThatThrows() async {
-        await verifyErrorThrown { error in
-            try await array.asyncMap { int in
-                try await self.collector.tryCollectAndTransform(
-                    int,
-                    throwError: int == 3 ? error : nil
-                )
+    func testThrowingAsyncMapThatDoesNotThrow() {
+        runAsyncTest { array, collector in
+            let values = try await array.asyncMap {
+                try await collector.tryCollectAndTransform($0)
             }
-        }
 
-        XCTAssertEqual(collector.values, [0, 1, 2])
+            XCTAssertEqual(values, array.map(String.init))
+        }
     }
 
-    func testNonThrowingConcurrentMap() async {
-        let values = await array.concurrentMap {
-            await self.collector.collectAndTransform($0)
-        }
-
-        XCTAssertEqual(values, array.map(String.init))
-    }
-
-    func testThrowingConcurrentMapThatDoesNotThrow() async throws {
-        let values = try await array.concurrentMap {
-            try await self.collector.tryCollectAndTransform($0)
-        }
-
-        XCTAssertEqual(values, array.map(String.init))
-    }
-
-    func testThrowingConcurrentMapThatThrows() async {
-        await verifyErrorThrown { error in
-            try await array.concurrentMap { int in
-                try await self.collector.tryCollectAndTransform(
-                    int,
-                    throwError: int == 3 ? error : nil
-                )
+    func testThrowingAsyncMapThatThrows() {
+        runAsyncTest { array, collector in
+            await self.verifyErrorThrown { error in
+                try await array.asyncMap { int in
+                    try await collector.tryCollectAndTransform(
+                        int,
+                        throwError: int == 3 ? error : nil
+                    )
+                }
             }
-        }
 
-        XCTAssertEqual(collector.values.sorted(), [0, 1, 2, 4])
+            XCTAssertEqual(collector.values, [0, 1, 2])
+        }
+    }
+
+    func testNonThrowingConcurrentMap() {
+        runAsyncTest { array, collector in
+            let values = await array.concurrentMap {
+                await collector.collectAndTransform($0)
+            }
+
+            XCTAssertEqual(values, array.map(String.init))
+        }
+    }
+
+    func testThrowingConcurrentMapThatDoesNotThrow() {
+        runAsyncTest { array, collector in
+            let values = try await array.concurrentMap {
+                try await collector.tryCollectAndTransform($0)
+            }
+
+            XCTAssertEqual(values, array.map(String.init))
+        }
+    }
+
+    func testThrowingConcurrentMapThatThrows() {
+        runAsyncTest { array, collector in
+            await self.verifyErrorThrown { error in
+                try await array.concurrentMap { int in
+                    try await collector.tryCollectAndTransform(
+                        int,
+                        throwError: int == 3 ? error : nil
+                    )
+                }
+            }
+
+            XCTAssertEqual(collector.values.sorted(), [0, 1, 2, 4])
+        }
     }
 }

--- a/Tests/TestCase.swift
+++ b/Tests/TestCase.swift
@@ -31,6 +31,35 @@ class TestCase: XCTestCase {
             XCTFail("Incorrect error thrown: \(error)", file: file, line: line)
         }
     }
+
+    func runAsyncTest(
+        named testName: String = #function,
+        in file: StaticString = #file,
+        at line: UInt = #line,
+        withTimeout timeout: TimeInterval = 10,
+        test: @escaping ([Int], Collector) async throws -> Void
+    ) {
+        // This method is needed since Linux doesn't yet support async test methods.
+        var thrownError: Error?
+        let errorHandler = { thrownError = $0 }
+        let expectation = expectation(description: testName)
+
+        Task {
+            do {
+                try await test(array, collector)
+            } catch {
+                errorHandler(error)
+            }
+
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout)
+
+        if let error = thrownError {
+            XCTFail("Async error thrown: \(error)", file: file, line: line)
+        }
+    }
 }
 
 extension TestCase {


### PR DESCRIPTION
Swift's test auto-discovery feature doesn't seem to work with asynchronous unit tests on Linux just yet. So, for now, we'll wrap all of our testing logic using a `runAsyncTest` utility method that can be executed synchronously.