### PR TITLE
Tests: Don't assume that all concurrent tasks will run when throwing an error

### DIFF
--- a/Tests/CompactMapTests.swift
+++ b/Tests/CompactMapTests.swift
@@ -67,14 +67,12 @@ final class CompactMapTests: TestCase {
         runAsyncTest { array, collector in
             await self.verifyErrorThrown { error in
                 try await array.concurrentCompactMap { int in
-                    int == 2 ? nil : try await self.collector.tryCollectAndTransform(
+                    try await self.collector.tryCollectAndTransform(
                         int,
                         throwError: int == 3 ? error : nil
                     )
                 }
             }
-
-            XCTAssertEqual(collector.values.sorted(), [0, 1, 4])
         }
     }
 }

--- a/Tests/FlatMapTests.swift
+++ b/Tests/FlatMapTests.swift
@@ -73,8 +73,6 @@ final class FlatMapTests: TestCase {
                     )
                 }
             }
-
-            XCTAssertEqual(collector.values.sorted(), [0, 1, 2, 4])
         }
     }
 }

--- a/Tests/ForEachTests.swift
+++ b/Tests/ForEachTests.swift
@@ -61,8 +61,6 @@ final class ForEachTests: TestCase {
                     )
                 }
             }
-
-            XCTAssertEqual(collector.values.count, array.count - 1)
         }
     }
 }

--- a/Tests/MapTests.swift
+++ b/Tests/MapTests.swift
@@ -70,8 +70,6 @@ final class MapTests: TestCase {
                     )
                 }
             }
-
-            XCTAssertEqual(collector.values.sorted(), [0, 1, 2, 4])
         }
     }
 }


### PR DESCRIPTION
If the error gets thrown before some tasks have had a chance to run, then the collector won't actually collect all values, so we can't assume that it will. Instead, we now only verify that those throwing concurrent tasks actually end up throwing an error.