### PR TITLE
Lower target platform versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ import PackageDescription
 
 let package = Package(
     name: "CollectionConcurrencyKit",
-    platforms: [.iOS(.v15), .macOS(.v12), .watchOS(.v8), .tvOS(.v15)],
+    platforms: [.iOS(.v13), .macOS(.v10_15), .watchOS(.v6), .tvOS(.v13)],
     products: [
         .library(
             name: "CollectionConcurrencyKit",


### PR DESCRIPTION
Now that Xcode 13.2 has gone public, we can lower the minimum required target versions to go with the backported concurrency features.