### PR TITLE
Use TaskGroups instead of array of tasks

### DIFF
--- a/Sources/CollectionConcurrencyKit.swift
+++ b/Sources/CollectionConcurrencyKit.swift
@@ -121,14 +121,18 @@ public extension Sequence {
         withPriority priority: TaskPriority? = nil,
         _ transform: @escaping (Element) async -> T
     ) async -> [T] {
-        let tasks = map { element in
-            Task(priority: priority) {
-                await transform(element)
+        return await withTaskGroup(of: (offset: Int, value: T).self) { group in
+            for (idx, element) in enumerated() {
+                group.addTask(priority: priority) {
+                    return await (idx, transform(element))
+                }
             }
-        }
 
-        return await tasks.asyncMap { task in
-            await task.value
+            var res = [(offset: Int, value: T)]()
+            while let next = await group.next() {
+                res.append(next)
+            }
+            return res.sorted{ $0.offset < $1.offset }.map{ $0.value }
         }
     }
 
@@ -152,14 +156,18 @@ public extension Sequence {
         withPriority priority: TaskPriority? = nil,
         _ transform: @escaping (Element) async throws -> T
     ) async throws -> [T] {
-        let tasks = map { element in
-            Task(priority: priority) {
-                try await transform(element)
+        return try await withThrowingTaskGroup(of: (offset: Int, value: T).self) { group in
+            for (idx, element) in enumerated() {
+                group.addTask(priority: priority) {
+                    return try await (idx, transform(element))
+                }
             }
-        }
 
-        return try await tasks.asyncMap { task in
-            try await task.value
+            var res = [(offset: Int, value: T)]()
+            while let next = try await group.next() {
+                res.append(next)
+            }
+            return res.sorted{ $0.offset < $1.offset }.map{ $0.value }
         }
     }
 }
@@ -216,14 +224,20 @@ public extension Sequence {
         withPriority priority: TaskPriority? = nil,
         _ transform: @escaping (Element) async -> T?
     ) async -> [T] {
-        let tasks = map { element in
-            Task(priority: priority) {
-                await transform(element)
+        return await withTaskGroup(of: (offset: Int, value: T?).self) { group in
+            for (idx, element) in enumerated() {
+                group.addTask(priority: priority) {
+                    return await (idx, transform(element))
+                }
             }
-        }
 
-        return await tasks.asyncCompactMap { task in
-            await task.value
+            var res = [(offset: Int, value: T)]()
+            while let next = await group.next() {
+                if let v = next.value {
+                    res.append((offset: next.offset, value: v))
+                }
+            }
+            return res.sorted{ $0.offset < $1.offset }.map{ $0.value }
         }
     }
 
@@ -249,14 +263,20 @@ public extension Sequence {
         withPriority priority: TaskPriority? = nil,
         _ transform: @escaping (Element) async throws -> T?
     ) async throws -> [T] {
-        let tasks = map { element in
-            Task(priority: priority) {
-                try await transform(element)
+        return try await withThrowingTaskGroup(of: (offset: Int, value: T?).self) { group in
+            for (idx, element) in enumerated() {
+                group.addTask(priority: priority) {
+                    return try await (idx, transform(element))
+                }
             }
-        }
 
-        return try await tasks.asyncCompactMap { task in
-            try await task.value
+            var res = [(offset: Int, value: T)]()
+            while let next = try await group.next() {
+                if let v = next.value {
+                    res.append((offset: next.offset, value: v))
+                }
+            }
+            return res.sorted{ $0.offset < $1.offset }.map{ $0.value }
         }
     }
 }
@@ -311,14 +331,18 @@ public extension Sequence {
         withPriority priority: TaskPriority? = nil,
         _ transform: @escaping (Element) async -> T
     ) async -> [T.Element] {
-        let tasks = map { element in
-            Task(priority: priority) {
-                await transform(element)
+        return await withTaskGroup(of: (offset: Int, value: T).self) { group in
+            for (idx, element) in enumerated() {
+                group.addTask(priority: priority) {
+                    return await (idx, transform(element))
+                }
             }
-        }
 
-        return await tasks.asyncFlatMap { task in
-            await task.value
+            var res = [(offset: Int, value: T)]()
+            while let next = await group.next() {
+                res.append(next)
+            }
+            return res.sorted{ $0.offset < $1.offset }.flatMap{ $0.value }
         }
     }
 
@@ -345,14 +369,18 @@ public extension Sequence {
         withPriority priority: TaskPriority? = nil,
         _ transform: @escaping (Element) async throws -> T
     ) async throws -> [T.Element] {
-        let tasks = map { element in
-            Task(priority: priority) {
-                try await transform(element)
+        return try await withThrowingTaskGroup(of: (offset: Int, value: T).self) { group in
+            for (idx, element) in enumerated() {
+                group.addTask(priority: priority) {
+                    return try await (idx, transform(element))
+                }
             }
-        }
 
-        return try await tasks.asyncFlatMap { task in
-            try await task.value
+            var res = [(offset: Int, value: T)]()
+            while let next = try await group.next() {
+                res.append(next)
+            }
+            return res.sorted{ $0.offset < $1.offset }.flatMap{ $0.value }
         }
     }
 }

--- a/Sources/CollectionConcurrencyKit.swift
+++ b/Sources/CollectionConcurrencyKit.swift
@@ -128,11 +128,18 @@ public extension Sequence {
                 }
             }
 
-            var res = [(offset: Int, value: T)]()
+            var c = 0
+            var res = Array<T?>(repeating: nil, count: c)
             while let next = await group.next() {
-                res.append(next)
+                let delta = next.offset - c + 1
+                if delta > 0 {
+                    /* The res array is too small; we have to expand it. */
+                    res.append(contentsOf: Array<T?>(repeating: nil, count: delta))
+                    c += delta
+                }
+                res[next.offset] = next.value
             }
-            return res.sorted{ $0.offset < $1.offset }.map{ $0.value }
+            return res as! [T]
         }
     }
 
@@ -163,11 +170,18 @@ public extension Sequence {
                 }
             }
 
-            var res = [(offset: Int, value: T)]()
+            var c = 0
+            var res = Array<T?>(repeating: nil, count: c)
             while let next = try await group.next() {
-                res.append(next)
+                let delta = next.offset - c + 1
+                if delta > 0 {
+                    /* The res array is too small; we have to expand it. */
+                    res.append(contentsOf: Array<T?>(repeating: nil, count: delta))
+                    c += delta
+                }
+                res[next.offset] = next.value
             }
-            return res.sorted{ $0.offset < $1.offset }.map{ $0.value }
+            return res as! [T]
         }
     }
 }
@@ -231,13 +245,18 @@ public extension Sequence {
                 }
             }
 
-            var res = [(offset: Int, value: T)]()
+            var c = 0
+            var res = Array<T??>(repeating: nil, count: c)
             while let next = await group.next() {
-                if let v = next.value {
-                    res.append((offset: next.offset, value: v))
+                let delta = next.offset - c + 1
+                if delta > 0 {
+                    /* The res array is too small; we have to expand it. */
+                    res.append(contentsOf: Array<T?>(repeating: nil, count: delta))
+                    c += delta
                 }
+                res[next.offset] = next.value
             }
-            return res.sorted{ $0.offset < $1.offset }.map{ $0.value }
+            return (res as! [T?]).compactMap{ $0 }
         }
     }
 
@@ -270,13 +289,18 @@ public extension Sequence {
                 }
             }
 
-            var res = [(offset: Int, value: T)]()
+            var c = 0
+            var res = Array<T??>(repeating: nil, count: c)
             while let next = try await group.next() {
-                if let v = next.value {
-                    res.append((offset: next.offset, value: v))
+                let delta = next.offset - c + 1
+                if delta > 0 {
+                    /* The res array is too small; we have to expand it. */
+                    res.append(contentsOf: Array<T?>(repeating: nil, count: delta))
+                    c += delta
                 }
+                res[next.offset] = next.value
             }
-            return res.sorted{ $0.offset < $1.offset }.map{ $0.value }
+            return (res as! [T?]).compactMap{ $0 }
         }
     }
 }
@@ -338,11 +362,18 @@ public extension Sequence {
                 }
             }
 
-            var res = [(offset: Int, value: T)]()
+            var c = 0
+            var res = Array<T?>(repeating: nil, count: c)
             while let next = await group.next() {
-                res.append(next)
+                let delta = next.offset - c + 1
+                if delta > 0 {
+                    /* The res array is too small; we have to expand it. */
+                    res.append(contentsOf: Array<T?>(repeating: nil, count: delta))
+                    c += delta
+                }
+                res[next.offset] = next.value
             }
-            return res.sorted{ $0.offset < $1.offset }.flatMap{ $0.value }
+            return (res as! [T]).flatMap{ $0 }
         }
     }
 
@@ -376,11 +407,18 @@ public extension Sequence {
                 }
             }
 
-            var res = [(offset: Int, value: T)]()
+            var c = 0
+            var res = Array<T?>(repeating: nil, count: c)
             while let next = try await group.next() {
-                res.append(next)
+                let delta = next.offset - c + 1
+                if delta > 0 {
+                    /* The res array is too small; we have to expand it. */
+                    res.append(contentsOf: Array<T?>(repeating: nil, count: delta))
+                    c += delta
+                }
+                res[next.offset] = next.value
             }
-            return res.sorted{ $0.offset < $1.offset }.flatMap{ $0.value }
+            return (res as! [T]).flatMap{ $0 }
         }
     }
 }

--- a/Sources/CollectionConcurrencyKit.swift
+++ b/Sources/CollectionConcurrencyKit.swift
@@ -122,21 +122,17 @@ public extension Sequence {
         _ transform: @escaping (Element) async -> T
     ) async -> [T] {
         return await withTaskGroup(of: (offset: Int, value: T).self) { group in
-            for (idx, element) in enumerated() {
+            var c = 0
+            for element in self {
+                let idx = c
+                c += 1
                 group.addTask(priority: priority) {
                     return await (idx, transform(element))
                 }
             }
 
-            var c = 0
             var res = Array<T?>(repeating: nil, count: c)
             while let next = await group.next() {
-                let delta = next.offset - c + 1
-                if delta > 0 {
-                    /* The res array is too small; we have to expand it. */
-                    res.append(contentsOf: Array<T?>(repeating: nil, count: delta))
-                    c += delta
-                }
                 res[next.offset] = next.value
             }
             return res as! [T]
@@ -164,21 +160,17 @@ public extension Sequence {
         _ transform: @escaping (Element) async throws -> T
     ) async throws -> [T] {
         return try await withThrowingTaskGroup(of: (offset: Int, value: T).self) { group in
-            for (idx, element) in enumerated() {
+            var c = 0
+            for element in self {
+                let idx = c
+                c += 1
                 group.addTask(priority: priority) {
                     return try await (idx, transform(element))
                 }
             }
 
-            var c = 0
             var res = Array<T?>(repeating: nil, count: c)
             while let next = try await group.next() {
-                let delta = next.offset - c + 1
-                if delta > 0 {
-                    /* The res array is too small; we have to expand it. */
-                    res.append(contentsOf: Array<T?>(repeating: nil, count: delta))
-                    c += delta
-                }
                 res[next.offset] = next.value
             }
             return res as! [T]
@@ -239,21 +231,17 @@ public extension Sequence {
         _ transform: @escaping (Element) async -> T?
     ) async -> [T] {
         return await withTaskGroup(of: (offset: Int, value: T?).self) { group in
-            for (idx, element) in enumerated() {
+            var c = 0
+            for element in self {
+                let idx = c
+                c += 1
                 group.addTask(priority: priority) {
                     return await (idx, transform(element))
                 }
             }
 
-            var c = 0
             var res = Array<T??>(repeating: nil, count: c)
             while let next = await group.next() {
-                let delta = next.offset - c + 1
-                if delta > 0 {
-                    /* The res array is too small; we have to expand it. */
-                    res.append(contentsOf: Array<T?>(repeating: nil, count: delta))
-                    c += delta
-                }
                 res[next.offset] = next.value
             }
             return (res as! [T?]).compactMap{ $0 }
@@ -283,21 +271,17 @@ public extension Sequence {
         _ transform: @escaping (Element) async throws -> T?
     ) async throws -> [T] {
         return try await withThrowingTaskGroup(of: (offset: Int, value: T?).self) { group in
-            for (idx, element) in enumerated() {
+            var c = 0
+            for element in self {
+                let idx = c
+                c += 1
                 group.addTask(priority: priority) {
                     return try await (idx, transform(element))
                 }
             }
 
-            var c = 0
             var res = Array<T??>(repeating: nil, count: c)
             while let next = try await group.next() {
-                let delta = next.offset - c + 1
-                if delta > 0 {
-                    /* The res array is too small; we have to expand it. */
-                    res.append(contentsOf: Array<T?>(repeating: nil, count: delta))
-                    c += delta
-                }
                 res[next.offset] = next.value
             }
             return (res as! [T?]).compactMap{ $0 }
@@ -356,21 +340,17 @@ public extension Sequence {
         _ transform: @escaping (Element) async -> T
     ) async -> [T.Element] {
         return await withTaskGroup(of: (offset: Int, value: T).self) { group in
-            for (idx, element) in enumerated() {
+            var c = 0
+            for element in self {
+                let idx = c
+                c += 1
                 group.addTask(priority: priority) {
                     return await (idx, transform(element))
                 }
             }
 
-            var c = 0
             var res = Array<T?>(repeating: nil, count: c)
             while let next = await group.next() {
-                let delta = next.offset - c + 1
-                if delta > 0 {
-                    /* The res array is too small; we have to expand it. */
-                    res.append(contentsOf: Array<T?>(repeating: nil, count: delta))
-                    c += delta
-                }
                 res[next.offset] = next.value
             }
             return (res as! [T]).flatMap{ $0 }
@@ -401,21 +381,17 @@ public extension Sequence {
         _ transform: @escaping (Element) async throws -> T
     ) async throws -> [T.Element] {
         return try await withThrowingTaskGroup(of: (offset: Int, value: T).self) { group in
-            for (idx, element) in enumerated() {
+            var c = 0
+            for element in self {
+                let idx = c
+                c += 1
                 group.addTask(priority: priority) {
                     return try await (idx, transform(element))
                 }
             }
 
-            var c = 0
             var res = Array<T?>(repeating: nil, count: c)
             while let next = try await group.next() {
-                let delta = next.offset - c + 1
-                if delta > 0 {
-                    /* The res array is too small; we have to expand it. */
-                    res.append(contentsOf: Array<T?>(repeating: nil, count: delta))
-                    c += delta
-                }
                 res[next.offset] = next.value
             }
             return (res as! [T]).flatMap{ $0 }


### PR DESCRIPTION
_Reopening #7 that got closed because happn-app deleted their fork._

Rationale for this comes from this thread https://forums.swift.org/t/taskgroup-vs-an-array-of-tasks/53931
Apparently launching a lot of Tasks just like that is not very good, and we should use task groups instead.

I did not test the performance implication of this change, though. Maybe it’s actually worse because of the additional sort needed. In theory it should be better though.